### PR TITLE
Return Empty Dataframe on Error

### DIFF
--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -122,8 +122,10 @@ func (ds *GoogleSheetsDataSource) QueryData(ctx context.Context, req *backend.Qu
 
 		frame, err := ds.googlesheet.Query(ctx, q.RefID, queryModel, config, q.TimeRange)
 		if err != nil {
+			// here we need to return an empty dataframe
 			backend.Logger.Error("Query failed", "refId", q.RefID, "error", err)
-			return nil, err
+			res.Frames = append(res.Frames, []*data.Frame{}...)
+			return res, nil
 		}
 
 		res.Frames = append(res.Frames, []*data.Frame{frame}...)


### PR DESCRIPTION
I've had to change plugin logic to return an empty dataframe if an error is encountered (such as when a request range DNE). This is a pragmatic move to allow the engauged solar production to load in the graph unimpeded if there is no corresponding site sheet data.